### PR TITLE
Add support for USBCDC

### DIFF
--- a/TelnetSpy.cpp
+++ b/TelnetSpy.cpp
@@ -283,7 +283,12 @@ uint16_t TelnetSpy::getRecBufferSize() {
 	return recLen;
 }
 
+
+#if ARDUINO_USB_CDC_ON_BOOT
+void TelnetSpy::setSerial(USBCDC* usedSerial) {
+#else
 void TelnetSpy::setSerial(HardwareSerial* usedSerial) {
+#endif
 	usedSer = usedSerial;
 }
 
@@ -432,7 +437,11 @@ void TelnetSpy::begin(unsigned long baud, SerialConfig config, SerialMode mode, 
 
 void TelnetSpy::begin(unsigned long baud, uint32_t config, int8_t rxPin, int8_t txPin, bool invert) {
 	if (usedSer) {
+#if ARDUINO_USB_CDC_ON_BOOT
+		usedSer->begin(baud);
+#else
 		usedSer->begin(baud, config, rxPin, txPin, invert);
+#endif
 	}
     setDebugOutput(debugOutput);
 	started = true;

--- a/TelnetSpy.h
+++ b/TelnetSpy.h
@@ -293,7 +293,11 @@ class TelnetSpy : public Stream {
 		void setPingTime(uint16_t pngTime);
 		bool setRecBufferSize(uint16_t newSize);
 		uint16_t getRecBufferSize();
+#if ARDUINO_USB_CDC_ON_BOOT
+		void setSerial(USBCDC* usedSerial);
+#else
 		void setSerial(HardwareSerial* usedSerial);
+#endif
 		bool isClientConnected();
 		void setCallbackOnConnect(void (*callback)());
 		void setCallbackOnDisconnect(void (*callback)());
@@ -356,7 +360,11 @@ class TelnetSpy : public Stream {
 		WiFiServer* telnetServer;
 		WiFiClient client;
 		uint16_t port;
+#if ARDUINO_USB_CDC_ON_BOOT
+		USBCDC* usedSer;
+#else
 		HardwareSerial* usedSer;
+#endif
 		bool storeOffline;
 		bool started;
 		bool listening;


### PR DESCRIPTION
Allows use of this library with controllers that lack a distinct USB-to-UART chip such as the ESP32-S2